### PR TITLE
Enable Windows builds on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: rust
 rust:
   - stable
   - beta
-os: osx
+os:
+  - osx
+  - windows
 # Cache settings based on https://levans.fr/rust_travis_cache.html
 cache:
   directories:


### PR DESCRIPTION
Travis CI now supports Windows, I will disable the builds on appveyor.