### PR TITLE
Linux controller

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -3,7 +3,6 @@ use std::sync::mpsc;
 use crate::Error;
 use crate::ServiceEvent;
 
-// On platforms other than Windows we default to the dummy controller.
 cfg_if!{
     if #[cfg(windows)] {
         #[macro_use]
@@ -14,6 +13,10 @@ cfg_if!{
         mod macos;
         pub use self::macos::MacosController as Controller;
         pub use self::macos::dispatch;
+    } else if #[cfg(target_os = "linux")] {
+        mod linux;
+        pub use self::linux::LinuxController as Controller;
+        pub use self::linux::dispatch;
     } else {
         mod dummy;
         pub use self::dummy::DummyController as Controller;

--- a/src/controller/linux.rs
+++ b/src/controller/linux.rs
@@ -1,0 +1,184 @@
+use std::env;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::mpsc;
+
+use ctrlc;
+use log::{debug, info};
+
+use crate::controller::{ControllerInterface, ServiceMainFn};
+use crate::Error;
+use crate::ServiceEvent;
+
+type LinuxServiceMainWrapperFn = extern "system" fn(args: Vec<String>);
+
+fn systemctl_execute(args: &[&str]) -> Result<(), Error> {
+    let mut process = Command::new("systemctl");
+    process.args(args);
+
+    let output = process.output()
+        .map_err(|e| Error::new(&format!("Failed to execute command {}: {}", args[0], e)))?;
+
+    if !output.status.success() {
+        return Err(Error::new(&format!("Command \"{}\" failed ({}): {}", 
+            args[0], 
+            output.status.code().expect("Process terminated by signal"),
+            std::str::from_utf8(&output.stderr).unwrap_or_default())))
+    }
+
+    if output.stdout.len() > 0 {
+        info!("{}", String::from_utf8_lossy(&output.stdout));
+    }
+
+    Ok(())
+}
+
+fn systemd_install_daemon(name: &str) -> Result<(), Error> {
+    systemctl_execute(&["daemon-reload"])?;
+    systemctl_execute(&["enable", name])
+} 
+
+fn systemd_uninstall_daemon(name: &str) -> Result<(), Error> {
+    systemctl_execute(&["disable", name])?;
+    systemctl_execute(&["daemon-reload"]).map_err(|e| debug!("{}", e)).ok();
+    systemctl_execute(&["reset-failed"]).map_err(|e| debug!("{}", e)).ok();
+    
+    Ok(())
+}
+
+fn systemd_start_daemon(name: &str) -> Result<(), Error> {
+    systemctl_execute(&["start", name])
+}
+
+fn systemd_stop_daemon(name: &str) -> Result<(), Error> {
+    systemctl_execute(&["stop", name])
+}
+
+pub struct LinuxController {
+    pub service_name: String,
+    pub display_name: String,
+    pub description: String,
+    pub config: Option<String>,
+}
+
+impl LinuxController {
+    pub fn new(service_name: &str, display_name: &str, description: &str) -> LinuxController {
+        LinuxController {
+            service_name: service_name.to_string(),
+            display_name: display_name.to_string(),
+            description: description.to_string(),
+            config: None,
+        }
+    }
+
+    pub fn register(
+        &mut self,
+        service_main_wrapper: LinuxServiceMainWrapperFn,
+    ) -> Result<(), Error> {
+        service_main_wrapper(env::args().collect());
+        Ok(())
+    }
+
+    fn get_service_file_name(&self) -> String {
+        format!("{}.service", &self.service_name)
+    }
+
+    fn get_service_unit_path(&self) -> PathBuf {
+        Path::new("/lib/systemd/system/")
+            .join(self.get_service_file_name())
+    }
+
+    fn get_service_dropin_dir(&self) -> PathBuf {
+        Path::new("/lib/systemd/system/")
+            .join(format!("{}.d", self.get_service_file_name()))
+    }
+
+    fn get_service_unit_content(&self) -> Result<String, Error> {
+        Ok(format!(r#"
+[Unit]
+Description={}
+
+[Service]
+ExecStart={}
+
+[Install]
+WantedBy=multi-user.target"#, 
+        self.service_name,
+        fs::read_link("/proc/self/exe")
+            .map_err(|e| Error::new(&format!("Failed to read /proc/self/exe: {}", e)))?
+            .to_str().ok_or("Failed to parse /proc/self/exe")?))
+    }
+
+    fn write_service_config(&self) -> Result<(), Error> {
+        let path = self.get_service_unit_path();
+        let content = self.get_service_unit_content()?;
+        info!("Writing service file {}", path.display());
+        File::create(&path)
+            .and_then(|mut file| file.write_all(content.as_bytes()))
+            .map_err(|e| Error::new(&format!("Failed to write {}: {}", path.display(), e)))?;
+
+        if let Some(ref config) = self.config {
+            let path = self.get_service_dropin_dir().join(format!("{}.conf", self.service_name));
+            fs::create_dir(path.parent().unwrap())
+                .map_err(|e| Error::new(&format!("Failed to create {}: {}", path.display(), e)))?;
+            info!("Writing config file {}", path.display());
+            File::create(&path)
+                .and_then(|mut file| file.write_all(config.as_bytes()))
+                .map_err(|e| Error::new(&format!("Failed to write {}: {}", path.display(), e)))?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ControllerInterface for LinuxController {
+    fn create(&mut self) -> Result<(), Error> {
+        self.write_service_config()?;
+        
+        systemd_install_daemon(&self.service_name)
+    }
+
+    fn delete(&mut self) -> Result<(), Error> {
+        systemd_uninstall_daemon(&self.service_name)?;
+
+        let path = self.get_service_unit_path();
+        fs::remove_file(&path)
+            .map_err(|e| debug!("Failed to delete {}: {}", path.display(), e)).ok();
+
+        let path = self.get_service_dropin_dir();
+        fs::remove_dir_all(self.get_service_dropin_dir())
+            .map_err(|e| debug!("Failed to delete {}: {}", path.display(), e)).ok();
+
+        Ok(())
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        systemd_start_daemon(&self.service_name)
+    }
+
+    fn stop(&mut self) -> Result<(), Error> {
+        systemd_stop_daemon(&self.service_name)
+    }
+}
+
+#[macro_export]
+macro_rules! Service {
+    ($name:expr, $function:ident) => {
+        extern "system" fn service_main_wrapper(args: Vec<String>) {
+            dispatch($function, args);
+        }
+    };
+}
+
+#[doc(hidden)]
+pub fn dispatch<T: Send + 'static>(service_main: ServiceMainFn<T>, args: Vec<String>) {
+    let (tx, rx) = mpsc::channel();
+    let _tx = tx.clone();
+
+    ctrlc::set_handler(move || {
+        let _ = tx.send(ServiceEvent::Stop);
+    }).expect("Failed to register Ctrl-C handler");
+    service_main(rx, _tx, args, false);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,12 @@ pub struct Error {
     pub message: String,
 }
 
+impl From<&str> for Error {
+    fn from(message: &str) -> Self {
+        Error { message: message.to_string() }
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "{}", self.message,)


### PR DESCRIPTION
Add a simple Linux controller using systemd

The controller writes a minimalist unit file to /lib/systemd/system/{servicename}.service

The consumer can provide a more complete configuration by setting the `config` property of the controller.

