### PR TITLE
Linux Sessions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ winapi = { version = "0.3", features = ["winbase", "winerror", "winuser", "winsv
 widestring = {version = "0.3"}
 
 [target.'cfg(target_os = "linux")'.dependencies]
-systemd-rs = { path = "../systemd-rs" }
+systemd-rs = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ log = "0.4"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase", "winerror", "winuser", "winsvc", "libloaderapi", "errhandlingapi"] }
 widestring = {version = "0.3"}
+
+[target.'cfg(target_os = "linux")'.dependencies]
+systemd-rs = { path = "../systemd-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceviche"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/wayk/ceviche-rs"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -27,9 +27,9 @@ cfg_if!{
 /// `rx` receives the events that are sent to the service. `tx` can be used to send custom events on the channel.
 /// `args` is the list or arguments that were passed to the service. When `standalone_mode` is true, the service
 /// main function is being called directly (outside of the system service support).
-pub type ServiceMainFn<T> = fn(
-    rx: mpsc::Receiver<ServiceEvent<T>>,
-    tx: mpsc::Sender<ServiceEvent<T>>,
+pub type ServiceMainFn<T, A> = fn(
+    rx: mpsc::Receiver<ServiceEvent<T, A>>,
+    tx: mpsc::Sender<ServiceEvent<T, A>>,
     args: Vec<String>,
     standalone_mode: bool,
 ) -> u32;

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -16,6 +16,7 @@ cfg_if!{
     } else if #[cfg(target_os = "linux")] {
         mod linux;
         pub use self::linux::LinuxController as Controller;
+        pub use self::linux::Session as Session;
         pub use self::linux::dispatch;
     } else {
         mod dummy;
@@ -27,9 +28,9 @@ cfg_if!{
 /// `rx` receives the events that are sent to the service. `tx` can be used to send custom events on the channel.
 /// `args` is the list or arguments that were passed to the service. When `standalone_mode` is true, the service
 /// main function is being called directly (outside of the system service support).
-pub type ServiceMainFn<T, A> = fn(
-    rx: mpsc::Receiver<ServiceEvent<T, A>>,
-    tx: mpsc::Sender<ServiceEvent<T, A>>,
+pub type ServiceMainFn<T> = fn(
+    rx: mpsc::Receiver<ServiceEvent<T>>,
+    tx: mpsc::Sender<ServiceEvent<T>>,
     args: Vec<String>,
     standalone_mode: bool,
 ) -> u32;

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -13,6 +13,7 @@ cfg_if!{
     } else if #[cfg(target_os = "macos")] {
         mod macos;
         pub use self::macos::MacosController as Controller;
+        pub use self::macos::Session as Session;
         pub use self::macos::dispatch;
     } else if #[cfg(target_os = "linux")] {
         mod linux;

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -8,6 +8,7 @@ cfg_if!{
         #[macro_use]
         mod windows;
         pub use self::windows::WindowsController as Controller;
+        pub use self::windows::Session as Session;
         pub use self::windows::dispatch;
     } else if #[cfg(target_os = "macos")] {
         mod macos;

--- a/src/controller/linux.rs
+++ b/src/controller/linux.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fmt::Display;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -173,7 +174,7 @@ macro_rules! Service {
 }
 
 #[doc(hidden)]
-pub fn dispatch<T: Send + 'static>(service_main: ServiceMainFn<T>, args: Vec<String>) {
+pub fn dispatch<T: Display + Send + 'static, A: Send + 'static>(service_main: ServiceMainFn<T, A>, args: Vec<String>) {
     let (tx, rx) = mpsc::channel();
     let _tx = tx.clone();
 

--- a/src/controller/linux.rs
+++ b/src/controller/linux.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::fmt::Display;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -10,10 +9,12 @@ use ctrlc;
 use log::{debug, info};
 
 use crate::controller::{ControllerInterface, ServiceMainFn};
+use crate::session;
 use crate::Error;
 use crate::ServiceEvent;
 
 type LinuxServiceMainWrapperFn = extern "system" fn(args: Vec<String>);
+pub type Session = session::Session_<String>;
 
 fn systemctl_execute(args: &[&str]) -> Result<(), Error> {
     let mut process = Command::new("systemctl");
@@ -174,7 +175,7 @@ macro_rules! Service {
 }
 
 #[doc(hidden)]
-pub fn dispatch<T: Display + Send + 'static, A: Send + 'static>(service_main: ServiceMainFn<T, A>, args: Vec<String>) {
+pub fn dispatch<T: Send + 'static>(service_main: ServiceMainFn<T>, args: Vec<String>) {
     let (tx, rx) = mpsc::channel();
     let _tx = tx.clone();
 

--- a/src/controller/linux.rs
+++ b/src/controller/linux.rs
@@ -7,6 +7,8 @@ use std::sync::mpsc;
 
 use ctrlc;
 use log::{debug, info};
+use systemd_rs::login::monitor::{Category, Monitor};
+use systemd_rs::login::session as login_session;
 
 use crate::controller::{ControllerInterface, ServiceMainFn};
 use crate::session;
@@ -165,6 +167,48 @@ impl ControllerInterface for LinuxController {
     }
 }
 
+fn run_monitor<T: Send + 'static>(tx: mpsc::Sender<ServiceEvent<T>>) -> Result<Monitor, std::io::Error> {
+    let monitor = Monitor::new()?;
+
+    let mut current_session = match login_session::get_active_session() {
+        Ok(s) => Some(s),
+        Err(e) => {
+            debug!("Failed to get active session {}", e);
+            None
+        },
+    };
+
+    monitor.init(Category::Sessions, move || {
+        let active_session = match login_session::get_active_session() {
+            Ok(s) => Some(s),
+            Err(e) => {
+                debug!("Failed to get active session {}", e);
+                None
+            },
+        };
+
+        let session_changed = match (&current_session, &active_session) {
+            (Some(current_session), Some(active_session)) => current_session != active_session,
+            (None, None) => false,
+            _ => true,
+        };
+
+        if session_changed {
+            if let Some(current_session) = current_session.as_ref() {
+                let _ = tx.send(ServiceEvent::SessionDisconnect(Session::new(current_session.identifier.to_string())));
+            }
+
+            if let Some(active_session) = active_session.as_ref() {
+                let _ = tx.send(ServiceEvent::SessionLogon(Session::new(active_session.identifier.to_string())));
+            }
+        }
+
+        current_session = active_session;
+    })?;
+
+    Ok(monitor)
+}
+
 #[macro_export]
 macro_rules! Service {
     ($name:expr, $function:ident) => {
@@ -177,6 +221,7 @@ macro_rules! Service {
 #[doc(hidden)]
 pub fn dispatch<T: Send + 'static>(service_main: ServiceMainFn<T>, args: Vec<String>) {
     let (tx, rx) = mpsc::channel();
+    let _monitor = run_monitor(tx.clone()).expect("Failed to run session monitor");
     let _tx = tx.clone();
 
     ctrlc::set_handler(move || {

--- a/src/controller/linux.rs
+++ b/src/controller/linux.rs
@@ -194,12 +194,12 @@ fn run_monitor<T: Send + 'static>(tx: mpsc::Sender<ServiceEvent<T>>) -> Result<M
         };
 
         if session_changed {
-            if let Some(current_session) = current_session.as_ref() {
-                let _ = tx.send(ServiceEvent::SessionDisconnect(Session::new(current_session.identifier.to_string())));
+            if let Some(active_session) = active_session.as_ref() {
+                let _ = tx.send(ServiceEvent::SessionConnect(Session::new(active_session.identifier.to_string())));
             }
 
-            if let Some(active_session) = active_session.as_ref() {
-                let _ = tx.send(ServiceEvent::SessionLogon(Session::new(active_session.identifier.to_string())));
+            if let Some(current_session) = current_session.as_ref() {
+                let _ = tx.send(ServiceEvent::SessionDisconnect(Session::new(current_session.identifier.to_string())));
             }
         }
 
@@ -221,6 +221,7 @@ macro_rules! Service {
 #[doc(hidden)]
 pub fn dispatch<T: Send + 'static>(service_main: ServiceMainFn<T>, args: Vec<String>) {
     let (tx, rx) = mpsc::channel();
+    
     let _monitor = run_monitor(tx.clone()).expect("Failed to run session monitor");
     let _tx = tx.clone();
 

--- a/src/controller/macos.rs
+++ b/src/controller/macos.rs
@@ -9,10 +9,12 @@ use ctrlc;
 use log::info;
 
 use crate::controller::{ControllerInterface, ServiceMainFn};
+use crate::session;
 use crate::Error;
 use crate::ServiceEvent;
 
 type MacosServiceMainWrapperFn = extern "system" fn(args: Vec<String>);
+pub type Session = session::Session_<u32>;
 
 fn gen_service_plist(name: &str) -> String {
     format!(r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@ use std::fmt;
 
 /// Manages the service on the system.
 pub mod controller;
+pub mod session;
+
+use controller::Session;
 
 /// Service errors
 #[derive(Debug)]
@@ -109,20 +112,20 @@ impl Error {
 }
 
 /// Events that are sent to the service.
-pub enum ServiceEvent<T: fmt::Display, A> {
+pub enum ServiceEvent<T> {
     Continue,
     Pause,
     Stop,
-    SessionConnect(T),
-    SessionDisconnect(T),
-    SessionLogon(T),
-    SessionLogoff(T),
-    SessionLock(T),
-    SessionUnlock(T),
-    Custom(A),
+    SessionConnect(Session),
+    SessionDisconnect(Session),
+    SessionLogon(Session),
+    SessionLogoff(Session),
+    SessionLock(Session),
+    SessionUnlock(Session),
+    Custom(T),
 }
 
-impl<T: fmt::Display, A> fmt::Display for ServiceEvent<T, A>  {
+impl<T> fmt::Display for ServiceEvent<T>  {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
             ServiceEvent::Continue => write!(f, "Continue"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //!  enum CustomServiceEvent {}
 //!
 //! fn my_service_main(
-//!     rx: mpsc::Receiver<ServiceEvent<u32, CustomServiceEvent>>,
-//!     _tx: mpsc::Sender<ServiceEvent<u32, CustomServiceEvent>>,
+//!     rx: mpsc::Receiver<ServiceEvent<CustomServiceEvent>>,
+//!     _tx: mpsc::Sender<ServiceEvent<CustomServiceEvent>>,
 //!     args: Vec<String>,
 //!     standalone_mode: bool) -> u32 {
 //!    loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //!  enum CustomServiceEvent {}
 //!
 //! fn my_service_main(
-//!     rx: mpsc::Receiver<ServiceEvent<CustomServiceEvent>>,
-//!     _tx: mpsc::Sender<ServiceEvent<CustomServiceEvent>>,
+//!     rx: mpsc::Receiver<ServiceEvent<u32, CustomServiceEvent>>,
+//!     _tx: mpsc::Sender<ServiceEvent<u32, CustomServiceEvent>>,
 //!     args: Vec<String>,
 //!     standalone_mode: bool) -> u32 {
 //!    loop {
@@ -109,20 +109,20 @@ impl Error {
 }
 
 /// Events that are sent to the service.
-pub enum ServiceEvent<T> {
+pub enum ServiceEvent<T: fmt::Display, A> {
     Continue,
     Pause,
     Stop,
-    SessionConnect(u32),
-    SessionDisconnect(u32),
-    SessionLogon(u32),
-    SessionLogoff(u32),
-    SessionLock(u32),
-    SessionUnlock(u32),
-    Custom(T),
+    SessionConnect(T),
+    SessionDisconnect(T),
+    SessionLogon(T),
+    SessionLogoff(T),
+    SessionLock(T),
+    SessionUnlock(T),
+    Custom(A),
 }
 
-impl<T> fmt::Display for ServiceEvent<T> {
+impl<T: fmt::Display, A> fmt::Display for ServiceEvent<T, A>  {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
             ServiceEvent::Continue => write!(f, "Continue"),

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,24 @@
+use std::fmt::{Display, Formatter, Result};
+
+pub struct Session_<T: Display + PartialEq> {
+    pub id: T,
+    _private: ()
+}
+
+impl<T> Display for Session_<T> where T: Display + PartialEq {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "{}", self.id)
+    }
+}
+
+impl<T> PartialEq for Session_<T> where T: Display + PartialEq {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl<T> Session_<T> where T: Display + PartialEq {
+    fn new(id: T) -> Self {
+        Session_ { id, _private: () }
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -18,7 +18,7 @@ impl<T> PartialEq for Session_<T> where T: Display + PartialEq {
 }
 
 impl<T> Session_<T> where T: Display + PartialEq {
-    fn new(id: T) -> Self {
+    pub fn new(id: T) -> Self {
         Session_ { id, _private: () }
     }
 }


### PR DESCRIPTION
Implement a basic support for session events in the Linux controller, using systemd. It may be desirable to hide the session tracking implementation behind a trait/feature, so alternative implementations could be plugged in or just disabled entirely.

We are just monitoring the active session, and firing a connected/disconnected service event when it changes. The systemd monitor simply sets an event when the session changes, it doesn't tell us *what* has changed. We could implement something more complete by tracking all the sessions and manually determining what changed. The service events in ceviche are based on Windows services and don't map exactly to systemd.

The type of the session event now varies with the platform (session IDs are int on Windows, string on Linux). This is a breaking change on the existing API.

I incremented the version to 0.3.