### PR TITLE
Custom plist for macOS 

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -49,4 +49,12 @@ pub trait ControllerInterface {
     fn start(&mut self) -> Result<(), Error>;
     /// Stops the service.
     fn stop(&mut self) -> Result<(), Error>;
+    cfg_if!{
+        if #[cfg(target_os = "macos")] {
+            /// Loads the agent service.
+            fn load(&mut self) -> Result<(), Error>;
+            /// Unloads the agent service.
+            fn unload(&mut self) -> Result<(), Error>;
+        }
+    }
 }

--- a/src/controller/macos.rs
+++ b/src/controller/macos.rs
@@ -139,7 +139,7 @@ impl ControllerInterface for MacosController {
     /// Creates the service on the system.
     fn create(&mut self) -> Result<(), Error> {
         let plist_path = Path::new("/Library/")
-        .join(if self.is_agent == true { "LaunchAgents/" } else { "LaunchDaemons/"})
+        .join(if self.is_agent { "LaunchAgents/" } else { "LaunchDaemons/"})
         .join(format!("{}.plist", &self.service_name));
             
         self.write_plist(&plist_path)?;
@@ -148,7 +148,7 @@ impl ControllerInterface for MacosController {
     /// Deletes the service.
     fn delete(&mut self) -> Result<(), Error> {
         let plist_path = Path::new("/Library/")
-        .join(if self.is_agent == true { "LaunchAgents/" } else { "LaunchDaemons/"})
+        .join(if self.is_agent { "LaunchAgents/" } else { "LaunchDaemons/"})
         .join(format!("{}.plist", &self.service_name));
 
         launchctl_unload_daemon(&plist_path)?;

--- a/src/controller/macos.rs
+++ b/src/controller/macos.rs
@@ -155,21 +155,27 @@ impl ControllerInterface for MacosController {
     /// Deletes the service.
     fn delete(&mut self) -> Result<(), Error> {
         let plist_path = self.plist_path();
-
-        launchctl_unload_daemon(&plist_path)?;
+        if !self.is_agent {
+            launchctl_unload_daemon(&plist_path)?;
+        }
         fs::remove_file(&plist_path)
             .map_err(|e| Error::new(&format!("Failed to delete {}: {}", plist_path.display(), e)))
     }
     /// Starts the service.
     fn start(&mut self) -> Result<(), Error> {
-        if self.is_agent {
-            launchctl_load_daemon(&self.plist_path())?;
-        }
         launchctl_start_daemon(&self.service_name)
     }
     /// Stops the service.
     fn stop(&mut self) -> Result<(), Error> {
         launchctl_stop_daemon(&self.service_name)
+    }
+    // Loads the agent service.
+    fn load(&mut self) -> Result<(), Error> {
+        launchctl_load_daemon(&self.plist_path())
+    }
+    // Loads the agent service.
+    fn unload(&mut self) -> Result<(), Error> {
+        launchctl_unload_daemon(&self.plist_path())
     }
 }
 


### PR DESCRIPTION
This pull request incorporates changes with regards to ability to pass a custom plist as argument and differentiating Agent/Daemon registering. Load/unload methods were added to interface since Agent can't be loaded under root.