### PR TITLE
Better macro hygiene on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceviche"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/wayk/ceviche-rs"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -5,7 +5,6 @@ use crate::ServiceEvent;
 
 cfg_if!{
     if #[cfg(windows)] {
-        #[macro_use]
         mod windows;
         pub use self::windows::WindowsController as Controller;
         pub use self::windows::Session as Session;

--- a/src/controller/windows.rs
+++ b/src/controller/windows.rs
@@ -6,7 +6,6 @@ use std::sync::mpsc;
 use std::{thread, time};
 
 use widestring::WideCString;
-use winapi::{self, STRUCT};
 use winapi::shared::minwindef::*;
 use winapi::shared::winerror::*;
 use winapi::um::errhandlingapi::*;
@@ -15,6 +14,7 @@ use winapi::um::winbase::*;
 use winapi::um::winnt::*;
 use winapi::um::winsvc::*;
 use winapi::um::winuser::*;
+use winapi::{self, STRUCT};
 
 use crate::controller::{ControllerInterface, ServiceMainFn};
 use crate::session;
@@ -23,7 +23,7 @@ use crate::ServiceEvent;
 
 static mut SERVICE_CONTROL_HANDLE: SERVICE_STATUS_HANDLE = ptr::null_mut();
 
-STRUCT!{#[allow(non_snake_case)]
+STRUCT! {#[allow(non_snake_case)]
     struct SERVICE_DESCRIPTION_W {
     lpDescription: LPWSTR,
 }}
@@ -418,8 +418,8 @@ pub fn get_last_error_text() -> String {
 #[macro_export]
 macro_rules! Service {
     ($name:expr, $function:ident) => {
-        use winapi::shared::minwindef::DWORD;
-        use winapi::um::winnt::LPWSTR;
+        use $crate::winapi::shared::minwindef::DWORD;
+        use $crate::winapi::um::winnt::LPWSTR;
 
         extern "system" fn service_main_wrapper(argc: DWORD, argv: *mut LPWSTR) {
             dispatch($function, $name, argc, argv);
@@ -428,12 +428,7 @@ macro_rules! Service {
 }
 
 #[doc(hidden)]
-pub fn dispatch<T>(
-    service_main: ServiceMainFn<T>, 
-    name: &str, 
-    argc: DWORD, 
-    argv: *mut LPWSTR) 
-{
+pub fn dispatch<T>(service_main: ServiceMainFn<T>, name: &str, argc: DWORD, argv: *mut LPWSTR) {
     let args = get_args(argc, argv);
     let service_name = get_utf16(name);
     let (mut tx, rx) = mpsc::channel();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,13 +71,15 @@
 #[macro_use]
 extern crate cfg_if;
 
-use std::fmt;
-
 /// Manages the service on the system.
 pub mod controller;
 pub mod session;
 
-use controller::Session;
+#[cfg(windows)]
+pub use winapi;
+
+use self::controller::Session;
+use std::fmt;
 
 /// Service errors
 #[derive(Debug)]
@@ -87,7 +89,9 @@ pub struct Error {
 
 impl From<&str> for Error {
     fn from(message: &str) -> Self {
-        Error { message: message.to_string() }
+        Error {
+            message: message.to_string(),
+        }
     }
 }
 
@@ -127,7 +131,7 @@ pub enum ServiceEvent<T> {
     Custom(T),
 }
 
-impl<T> fmt::Display for ServiceEvent<T>  {
+impl<T> fmt::Display for ServiceEvent<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
             ServiceEvent::Continue => write!(f, "Continue"),
@@ -136,7 +140,9 @@ impl<T> fmt::Display for ServiceEvent<T>  {
             ServiceEvent::SessionConnect(id) => write!(f, "SessionConnect({})", id),
             ServiceEvent::SessionDisconnect(id) => write!(f, "SessionDisconnect({})", id),
             ServiceEvent::SessionRemoteConnect(id) => write!(f, "SessionRemoteConnect({})", id),
-            ServiceEvent::SessionRemoteDisconnect(id) => write!(f, "SessionRemoteDisconnect({})", id),
+            ServiceEvent::SessionRemoteDisconnect(id) => {
+                write!(f, "SessionRemoteDisconnect({})", id)
+            }
             ServiceEvent::SessionLogon(id) => write!(f, "SessionLogon({})", id),
             ServiceEvent::SessionLogoff(id) => write!(f, "SessionLogoff({})", id),
             ServiceEvent::SessionLock(id) => write!(f, "SessionLock({})", id),


### PR DESCRIPTION
The `Service!` macro on Windows was expecting `winapi` crate to be in current scope.
With this change it's not even required to add a dependency on `winapi` in the downstream project manifest.