### PR TITLE
Fix garbled service description string on Windows

### DIFF
--- a/src/controller/windows.rs
+++ b/src/controller/windows.rs
@@ -141,8 +141,10 @@ impl ControllerInterface for WindowsController {
 
             self.tag_id = tag_id;
 
+            let mut description = get_utf16(&self.description.as_str());
+
             let mut sd = SERVICE_DESCRIPTION_W {
-                lpDescription: get_utf16(self.description.as_str()).as_mut_ptr(),
+                lpDescription: description.as_mut_ptr()
             };
 
             let p_sd = &mut sd as *mut _ as *mut winapi::ctypes::c_void;


### PR DESCRIPTION
When we used ceviche-rs for one of our services on Windows we sometimes found a garbled service description string in the Services application. Further research showed a scoping issue on the Rust side. The result of `get_utf16()` 
is dropped before `SERVICE_DESCRIPTION_W` gets processed by `ChangeServiceConfig2W`. This PR fixes that by introducing a local variable that holds the UTF16 description.

Ref:

https://doc.rust-lang.org/reference/destructors.html#temporary-scopes
> the temporary scope of an expression is the smallest scope that contains the expression and is one of the following:
> .. a statement, ....

/cc @ArghScreen