### PR TITLE
refactor: replace winapi with windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ ctrlc = { version = "3.1", features = ["termination"] }
 log = "0.4"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winbase", "winerror", "winuser", "winsvc", "libloaderapi", "errhandlingapi"] }
 widestring = "0.4.3"
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_RemoteDesktop", "Win32_System_LibraryLoader", "Win32_UI_WindowsAndMessaging", 
+    "Win32_Security", "Win32_System_Services", "Win32_System_Diagnostics_Debug"]}
 
 [target.'cfg(target_os = "linux")'.dependencies]
 systemd-rs = { version="^0.1.2", optional = true }

--- a/cmdlet/Cargo.toml
+++ b/cmdlet/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 [dependencies]
 libc = "0"
 log = "0.4"
-log4rs = "0.8"
+log4rs = "1.3"
 ctrlc = "3.1"
 cfg-if = "0.1"
 base64 = "0.12"
@@ -19,9 +19,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 which = { version = "3.0", default-features = false, features = [] }
 expand_str = "0.1"
-
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winbase", "winuser", "winsvc", "libloaderapi", "errhandlingapi", "winerror"] }
 
 [target.'cfg(windows)'.build-dependencies]
 embed-resource =  "1.3"

--- a/examples/foobar/Cargo.toml
+++ b/examples/foobar/Cargo.toml
@@ -16,12 +16,9 @@ path = "src/main.rs"
 [dependencies]
 libc = "0"
 log = "0.4"
-log4rs = "0.8"
+log4rs = "1.3"
 clap = { version = "2.31", features = ["yaml"] }
 ctrlc = "3.1"
-
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winbase", "winuser", "winsvc", "libloaderapi", "errhandlingapi", "winerror"] }
 
 [dependencies.ceviche]
 path = "../.."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub mod controller;
 pub mod session;
 
 #[cfg(windows)]
-pub use winapi;
+pub use windows_sys;
 
 use self::controller::Session;
 use std::fmt;


### PR DESCRIPTION
This pull request replaces `winapi` with the `windows-sys` crate as winapi is abandonned (see https://github.com/Devolutions/sspi-rs/issues/174). I went with `windows-sys` as its a more direct translation from winapi, some calls would be more idiomatic with `windows` but it would need a lot more work to convert the existing code.

I tested that the foobar example service still works correctly.

I also updated log4rs to 1.3, with the current version cargo warns that one of its dependency `traitobject` contains code that will be rejected in a future version of the Rust compiler.